### PR TITLE
Document dependency on Python 2, and try to run the addon with this specific version

### DIFF
--- a/.todo.actions.d/README.md
+++ b/.todo.actions.d/README.md
@@ -1,5 +1,5 @@
 # About
-Push or Pull todo items to and from Google Tasks. 
+Push or Pull todo items to and from Google Tasks.
 
 Examples:
 <pre><code>$ todo.sh google pull       #pulls tasks from Google
@@ -14,7 +14,7 @@ $ todo.sh google push all   #push todo and done items to Google
 - Create a project in the Google APIs Console (http://code.google.com/apis/console).
 - Under "APIs" enable the Tasks API
 - Under "Credentials" create a new Client Id for an installed application
-- Enter the Google-provided Client ID and Client Secret in the variables at the start of the addon script.	
+- Enter the Google-provided Client ID and Client Secret in the variables at the start of the addon script.
 
 ### Install Dependencies
 ```bash
@@ -32,10 +32,10 @@ or manually install from https://developers.google.com/api-client-library/python
 # Notes:
 Note that for simplicity, the 'archive' command is executed prior to the sync.
 
-- 'pull' will fetch google tasks and add them to your todo and done lists. Tasks will be pulled from all Google Task lists	
+- 'pull' will fetch google tasks and add them to your todo and done lists. Tasks will be pulled from all Google Task lists
 - 'push' command will push your todo list from todo.txt to Google Tasks
 - 'push all' command will push items from both todo.txt and done.txt
-  
+
 Currently all new tasks will be added to the default Google Task list. (This may change in the future)
 
 As this is a pull/push, there are obviously limitations to the syncing. For instance an already pushed  todo that is editted considerably will get pushed as a separate task as there is no way to match old and new. I've tried to allow for some of the more common and minor changes, such as marking a todo with a priority. Also, completing a todo or task can be synced up or down accordingly.

--- a/.todo.actions.d/README.md
+++ b/.todo.actions.d/README.md
@@ -8,6 +8,7 @@ $ todo.sh google push all   #push todo and done items to Google
 </code></pre>
 
 # Installation
+- Install Python 2. (This addon currently does NOT work with Python 3.)
 - Download the addon script and put into your todo.actions.d folder
 
 ### Enable Google API Access

--- a/.todo.actions.d/google
+++ b/.todo.actions.d/google
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # The client_id and client_secret are copied from the API Access tab on
 # the Google APIs Console


### PR DESCRIPTION
These days, with Python 3 becoming more and more popular, `/usr/bin/python` is likely to point to an incompatible version. Using `/usr/bin/env python2` tries to specifically resolve Python 2, and then run the addon with that Python binary. Hopefully, this will mean things will work out of the box for more users.

On a side note, @amcintosh, is this addon this maintained? (Or at least, do you still use it yourself?)